### PR TITLE
Use a newer version of lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -475,7 +475,7 @@
         "js-yaml": "3.13.1",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.14",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -797,7 +797,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.14",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -952,10 +952,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1374,7 +1373,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.2",
-        "lodash": "4.17.11",
+        "lodash": "4.17.14",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "commander": "^2.11.0",
     "glob": "^7.1.2",
     "graphql": "^14.3.0",
-    "graphql-tools": "^4.0.4"
+    "graphql-tools": "^4.0.4",
+    "lodash": "^4.17.14"
   },
   "typescript": {
     "definition": "dist/index.d.ts"


### PR DESCRIPTION
use a newer version of lodash to escape the security warnning that was showing in when using older version.

[TESTING]
ran the unit tests, and tried it on a local repo.

*Issue #, if available:*

*Description of changes:*
CVE-2019-10744 
high severity
Vulnerable versions: < 4.17.13
Patched version: 4.17.13
Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
