### PR TITLE
Print merged Schema with directives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   -s, --schema [pattern]      Use a glob path that would define all of your schema files to merge them into a valid schema. (default: "").
   -r, --rules [pattern]       The file path for your custom rules to validate your operations, and your merged schema. To learn abot how to write your custom rules: check the README.md file  (default: "").
   -p, --operations [pattern]  Use a glob that that contains your graphql operation files to test against the merged schema file. (default: "").
-  -d, --disableDirectives [pattern] By default will merge the directives, unless this was set to true.
+  -d, --disableDirectives     By default will merge the directives, unless this was set to true.
   -h, --help                  output usage information.
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Options:
   -s, --schema [pattern]      Use a glob path that would define all of your schema files to merge them into a valid schema. (default: "").
   -r, --rules [pattern]       The file path for your custom rules to validate your operations, and your merged schema. To learn abot how to write your custom rules: check the README.md file  (default: "").
   -p, --operations [pattern]  Use a glob that that contains your graphql operation files to test against the merged schema file. (default: "").
+  -d, --disableDirectives [pattern] By default will merge the directives, unless this was set to true.
   -h, --help                  output usage information.
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0"
+        "@babel/highlight": "7.5.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
-        "esutils": "2.0.2",
+        "esutils": "2.0.3",
         "js-tokens": "4.0.0"
       },
       "dependencies": {
@@ -52,14 +52,17 @@
       "requires": {
         "@types/events": "3.0.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "8.10.49"
+        "@types/node": "8.10.54"
       }
     },
     "@types/graphql": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.2.tgz",
-      "integrity": "sha512-okXbUmdZFMO3AYBEJCcpJFPFDkKmIiZZBqWD5TmPtAv+GHfjD2qLZEI0PvZ8IWMU4ozoK2HV2lDxWjw4LbVlnw==",
-      "dev": true
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+      "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+      "dev": true,
+      "requires": {
+        "graphql": "14.5.8"
+      }
     },
     "@types/lab": {
       "version": "11.1.0",
@@ -79,13 +82,13 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.49"
+        "@types/node": "8.10.54"
       }
     },
     "@types/node": {
-      "version": "8.10.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
-      "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
+      "version": "8.10.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+      "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
       "dev": true
     },
     "@types/rimraf": {
@@ -156,20 +159,22 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.3"
+      }
     },
     "apollo-link": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
-      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
       "requires": {
         "apollo-utilities": "1.3.2",
         "ts-invariant": "0.4.4",
         "tslib": "1.10.0",
-        "zen-observable-ts": "0.8.19"
+        "zen-observable-ts": "0.8.20"
       }
     },
     "apollo-utilities": {
@@ -199,10 +204,16 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "esutils": "2.0.2",
+        "esutils": "2.0.3",
         "js-tokens": "3.0.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -292,24 +303,6 @@
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
         "supports-color": "5.5.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "chardet": {
@@ -368,9 +361,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -438,7 +431,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "2.0.3"
       }
     },
     "escape-string-regexp": {
@@ -460,10 +453,10 @@
         "debug": "3.2.6",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.3",
-        "eslint-visitor-keys": "1.0.0",
+        "eslint-visitor-keys": "1.1.0",
         "espree": "3.5.4",
         "esquery": "1.0.1",
-        "esutils": "2.0.2",
+        "esutils": "2.0.3",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.4",
@@ -475,7 +468,7 @@
         "js-yaml": "3.13.1",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.14",
+        "lodash": "4.17.15",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -485,7 +478,7 @@
         "progress": "2.0.3",
         "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
-        "semver": "5.7.0",
+        "semver": "5.7.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -518,13 +511,13 @@
       "dev": true,
       "requires": {
         "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "estraverse": "4.3.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
@@ -549,7 +542,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "4.3.0"
       }
     },
     "esrecurse": {
@@ -558,19 +551,19 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "4.3.0"
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "external-editor": {
@@ -633,9 +626,20 @@
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
-        "graceful-fs": "4.2.0",
+        "graceful-fs": "4.2.2",
         "rimraf": "2.6.3",
         "write": "0.2.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.4"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -669,15 +673,15 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
     "graphql": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.1.tgz",
-      "integrity": "sha512-g4HUH26CohlMjaHneXMAtvG3QtO6peJIUTFxrPW4g5LNnXkUuFoBI6Bk1c14Q5kW8+FyjM/tTbePTgpiVB/2hQ==",
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
       "requires": {
         "iterall": "1.2.2"
       }
@@ -687,17 +691,17 @@
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
       "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
       "requires": {
-        "apollo-link": "1.2.12",
+        "apollo-link": "1.2.13",
         "apollo-utilities": "1.3.2",
         "deprecated-decorator": "0.1.6",
         "iterall": "1.2.2",
-        "uuid": "3.3.2"
+        "uuid": "3.3.3"
       }
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "2.6.1",
@@ -797,7 +801,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.14",
+        "lodash": "4.17.15",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -929,7 +933,7 @@
         "eslint-plugin-hapi": "4.1.0",
         "espree": "3.5.4",
         "find-rc": "3.0.1",
-        "handlebars": "4.1.2",
+        "handlebars": "4.4.2",
         "hoek": "4.2.1",
         "items": "2.1.2",
         "json-stable-stringify": "1.0.1",
@@ -939,6 +943,23 @@
         "source-map": "0.6.1",
         "source-map-support": "0.4.18",
         "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "levn": {
@@ -952,9 +973,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1165,9 +1186,9 @@
       }
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.6"
@@ -1190,9 +1211,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
         "glob": "7.1.4"
@@ -1241,9 +1262,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "shebang-command": {
@@ -1348,20 +1369,11 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "2.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        }
+        "has-flag": "3.0.0"
       }
     },
     "table": {
@@ -1373,7 +1385,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.2",
-        "lodash": "4.17.14",
+        "lodash": "4.17.15",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }
@@ -1422,24 +1434,32 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
+      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
+        "@babel/code-frame": "7.5.5",
         "builtin-modules": "1.1.1",
         "chalk": "2.4.2",
-        "commander": "2.20.0",
-        "diff": "3.5.0",
+        "commander": "2.20.1",
+        "diff": "4.0.1",
         "glob": "7.1.4",
         "js-yaml": "3.13.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "resolve": "1.11.1",
-        "semver": "5.7.0",
+        "resolve": "1.12.0",
+        "semver": "5.7.1",
         "tslib": "1.10.0",
         "tsutils": "2.29.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
       }
     },
     "tsutils": {
@@ -1467,9 +1487,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "uglify-js": {
@@ -1479,7 +1499,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "2.20.1",
         "source-map": "0.6.1"
       }
     },
@@ -1490,9 +1510,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "which": {
       "version": "1.3.1",
@@ -1535,9 +1555,9 @@
       "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
     },
     "zen-observable-ts": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
-      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
       "requires": {
         "tslib": "1.10.0",
         "zen-observable": "0.8.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Merge GraphQL Schema files and validate queries against the merged Schema",
   "repository": {
     "type": "git",

--- a/src/cli-launcher.ts
+++ b/src/cli-launcher.ts
@@ -25,7 +25,7 @@ program
     'The file path for your custom rules to validate your operations, and your merged schema.', '')
   .option('-p, --operations [pattern]',
     'Use a glob that that contains your graphql operation files to test against the merged schema file.', '')
-  .option('-d, --disableDirectives [pattern]',
+  .option('-d, --disableDirectives',
     'By default will merge the directives, unless this was set to true.', false)
   .parse(process.argv);
 

--- a/src/cli-launcher.ts
+++ b/src/cli-launcher.ts
@@ -11,19 +11,22 @@ import * as graphql from 'graphql';
 import * as path from 'path';
 import * as cli from './cli';
 import { consoleLogger } from './logger';
+import { printSchemaWithDirectives } from './utilities';
 // @ts-ignore
 const packageJson = require('../package.json');
 program
   .version(packageJson.version)
   .usage(`[options] (<glob.graphql>)`)
   .option('-o, --output [pattern]',
-   'The file path where the merged schema will be outputted to.')
+    'The file path where the merged schema will be outputted to.')
   .option('-s, --schema [pattern]',
-   'Use a glob path that would define all of your schema files to merge them into a valid schema.', '')
+    'Use a glob path that would define all of your schema files to merge them into a valid schema.', '')
   .option('-r, --rules [pattern]',
-   'The file path for your custom rules to validate your operations, and your merged schema.', '')
+    'The file path for your custom rules to validate your operations, and your merged schema.', '')
   .option('-p, --operations [pattern]',
-   'Use a glob that that contains your graphql operation files to test against the merged schema file.', '')
+    'Use a glob that that contains your graphql operation files to test against the merged schema file.', '')
+  .option('-d, --disableDirectives [pattern]',
+    'By default will merge the directives, unless this was set to true.', false)
   .parse(process.argv);
 
 if (!program.schema) {
@@ -31,7 +34,12 @@ if (!program.schema) {
 } else {
   cli.mergeGQLSchemas(program.schema)
     .then((schema) => {
-      let data = graphql.printSchema(schema);
+      let data = '';
+      if (program.disableDirectives) {
+        data = graphql.printSchema(schema);
+      } else {
+        data = printSchemaWithDirectives(schema);
+      }
       if (schema.getQueryType().toString() === 'Query' && (!schema.getMutationType()
         || schema.getMutationType().toString() === 'Mutation')
         && (!schema.getSubscriptionType()
@@ -74,7 +82,7 @@ if (!program.schema) {
         }
       }
     },
-    )
+  )
     .catch((err) => {
       consoleLogger.error('Could not merge Schema files!\n');
       process.exit(1);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as globUtil from 'glob';
+import { GraphQLSchema, isSpecifiedDirective, isSpecifiedScalarType, print } from 'graphql';
 
 export function readGlob(pattern: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -18,4 +19,29 @@ export function readFile(file: string): Promise<string> {
       err ? reject(err) : resolve(data),
     );
   });
+}
+
+/**
+ * This method is a workaround for the issue of not being able to print the
+ * directives fields for the merged schema when using printSchema method
+ * @param schema
+ */
+export function printSchemaWithDirectives(schema: GraphQLSchema): string {
+  const str = Object
+    .keys(schema.getTypeMap())
+    .filter((k) => !k.match(/^__/))
+    .reduce((accum, name) => {
+      const type = schema.getType(name);
+      return !isSpecifiedScalarType(type)
+        ? accum += `${print(type.astNode)}\n`
+        : accum;
+    }, '');
+
+  return schema
+    .getDirectives()
+    .reduce((accum, d) => {
+      return !isSpecifiedDirective(d)
+        ? accum += `${print(d.astNode)}\n`
+        : accum;
+    }, str + `${print(schema.astNode)}\n`);
 }


### PR DESCRIPTION
[Summary]
This is to fix the issue where directives where not being generated after merging schema files.

*Issue #, if available:*

*Description of changes:*
add the method as a workaround for the issue of not being able to print the
 directives fields for the merged schema when using printSchema method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
