### PR TITLE
Rewrite of conditional printing with directives

### DIFF
--- a/fixtures/directiveSchemas/baseTypes.graphql
+++ b/fixtures/directiveSchemas/baseTypes.graphql
@@ -1,0 +1,20 @@
+type Foo @noArg {
+  bar: String!
+  qux: Int!
+  nestedFoo: NestedFoo! @nullArg(stringArg: null)
+}
+
+type NestedFoo {
+  id: ID!
+  bar: Bar!
+}
+
+enum Bar {
+  MORE @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14)
+  VALUES
+  EVERYONE
+}
+
+input Input {
+  field: String @nullArg(stringArg: "string")
+}

--- a/fixtures/directiveSchemas/directives.graphql
+++ b/fixtures/directiveSchemas/directives.graphql
@@ -1,0 +1,8 @@
+"""This directive demonstrates using multiple args with multiple types."""
+directive @multiArgAndType(stringArg: String!, booleanArg: Boolean!, intArg: Int!, floatArg: Float!) on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+# This directive demonstrates using no args. And using comment syntax instead
+directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+"""This directive demonstrates null types."""
+directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT

--- a/fixtures/directiveSchemas/extendedTypes.graphql
+++ b/fixtures/directiveSchemas/extendedTypes.graphql
@@ -1,0 +1,4 @@
+extend type NestedFoo {
+  anotherAttribute: String! @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14) @noArg
+  oldAttribute: String! @deprecated(reason: "reason")
+}

--- a/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
@@ -1,0 +1,33 @@
+"""This directive demonstrates using multiple args with multiple types."""
+directive @multiArgAndType(stringArg: String!, booleanArg: Boolean!, intArg: Int!, floatArg: Float!) on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+"""
+This directive demonstrates using no args. And using comment syntax instead
+"""
+directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+"""This directive demonstrates null types."""
+directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT
+
+enum Bar {
+  MORE
+  VALUES
+  EVERYONE
+}
+
+type Foo {
+  bar: String!
+  qux: Int!
+  nestedFoo: NestedFoo!
+}
+
+input Input {
+  field: String
+}
+
+type NestedFoo {
+  id: ID!
+  bar: Bar!
+  anotherAttribute: String!
+  oldAttribute: String! @deprecated(reason: "reason")
+}

--- a/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
@@ -1,0 +1,33 @@
+"""This directive demonstrates using multiple args with multiple types."""
+directive @multiArgAndType(stringArg: String!, booleanArg: Boolean!, intArg: Int!, floatArg: Float!) on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+"""
+This directive demonstrates using no args. And using comment syntax instead
+"""
+directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
+
+"""This directive demonstrates null types."""
+directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT
+
+enum Bar {
+  MORE @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14)
+  VALUES
+  EVERYONE
+}
+
+type Foo @noArg {
+  bar: String!
+  qux: Int!
+  nestedFoo: NestedFoo! @nullArg(stringArg: null)
+}
+
+input Input {
+  field: String @nullArg(stringArg: "string")
+}
+
+type NestedFoo {
+  id: ID!
+  bar: Bar!
+  anotherAttribute: String! @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14) @noArg
+  oldAttribute: String! @deprecated(reason: "reason")
+}

--- a/fixtures/expectedOutput/helloWorld/expectedOutput.graphql
+++ b/fixtures/expectedOutput/helloWorld/expectedOutput.graphql
@@ -1,0 +1,37 @@
+"""Input type for a hello person."""
+input HelloPersonInput {
+  """
+  The name to set as the default for the helloPerson query when no name is provided to the query.  See helloPerson query for
+  more details.
+  """
+  name: String!
+}
+
+"""A root type for mutations"""
+type Mutation {
+  """
+  Sets the default helloPerson details used if no person name is provided in the helloPerson query.
+  """
+  setDefaultHelloPerson(helloPersonInput: HelloPersonInput!): String!
+}
+
+"""A root type for queries"""
+type Query {
+  """The Hello World! query."""
+  helloWorld: String!
+
+  """
+  The Hello <Name>! query.  That is, says hello to whatever String "name" is set to.  Defaults to the currently stored
+  default name as set by the setDefaultHelloPerson mutation or "Hello Everyone!", if no default name has been set yet.
+  """
+  helloPerson(name: String): String!
+}
+
+"""A root type for subscriptions"""
+type Subscription {
+  """
+  The hello person default name subscription.  Subscribes to events related to the changing of the default hello person
+  name.
+  """
+  defaultHelloPersonChanged: String!
+}

--- a/fixtures/helloWorld/mutations.graphql
+++ b/fixtures/helloWorld/mutations.graphql
@@ -1,0 +1,12 @@
+# A root type for mutations
+type Mutation {
+  # Sets the default helloPerson details used if no person name is provided in the helloPerson query.
+  setDefaultHelloPerson(helloPersonInput: HelloPersonInput!): String!
+}
+
+# Input type for a hello person.
+input HelloPersonInput {
+  # The name to set as the default for the helloPerson query when no name is provided to the query.  See helloPerson query for
+  # more details.
+  name: String!
+}

--- a/fixtures/helloWorld/queries.graphql
+++ b/fixtures/helloWorld/queries.graphql
@@ -1,0 +1,9 @@
+# A root type for queries
+type Query {
+  #  The Hello World! query.
+  helloWorld: String!
+
+  #  The Hello <Name>! query.  That is, says hello to whatever String "name" is set to.  Defaults to the currently stored
+  #  default name as set by the setDefaultHelloPerson mutation or "Hello Everyone!", if no default name has been set yet.
+  helloPerson(name: String): String!
+}

--- a/fixtures/helloWorld/subscriptions.graphql
+++ b/fixtures/helloWorld/subscriptions.graphql
@@ -1,0 +1,6 @@
+# A root type for subscriptions
+type Subscription {
+  #  The hello person default name subscription.  Subscribes to events related to the changing of the default hello person
+  #  name.
+  defaultHelloPersonChanged: String!
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.5.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "esutils": "2.0.3",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -50,9 +50,9 @@
       "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
       "dev": true,
       "requires": {
-        "@types/events": "3.0.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "8.10.54"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/graphql": {
@@ -61,7 +61,7 @@
       "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
       "dev": true,
       "requires": {
-        "graphql": "14.5.8"
+        "graphql": "*"
       }
     },
     "@types/lab": {
@@ -82,7 +82,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.54"
+        "@types/node": "*"
       }
     },
     "@types/node": {
@@ -102,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
       "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.3"
       }
     },
     "acorn": {
@@ -117,7 +117,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -134,10 +134,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -163,7 +163,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "apollo-link": {
@@ -171,10 +171,10 @@
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
       "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
       "requires": {
-        "apollo-utilities": "1.3.2",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0",
-        "zen-observable-ts": "0.8.20"
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.20"
       }
     },
     "apollo-utilities": {
@@ -182,10 +182,10 @@
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
       "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
       "requires": {
-        "@wry/equality": "0.1.9",
-        "fast-json-stable-stringify": "2.0.0",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "argparse": {
@@ -194,7 +194,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "babel-code-frame": {
@@ -203,9 +203,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.3",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -220,11 +220,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -233,7 +233,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -255,8 +255,8 @@
       "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1",
-        "joi": "10.6.0"
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
       }
     },
     "brace-expansion": {
@@ -264,7 +264,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -286,7 +286,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -300,9 +300,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -323,7 +323,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -344,7 +344,7 @@
       "integrity": "sha1-IJrRHQWvigwceq9pTZ+k0sfZW4U=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "color-convert": {
@@ -376,10 +376,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "core-util-is": {
@@ -394,9 +394,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.5",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "debug": {
@@ -405,7 +405,7 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.1"
       }
     },
     "deep-is": {
@@ -431,7 +431,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.3"
+        "esutils": "^2.0.2"
       }
     },
     "escape-string-regexp": {
@@ -445,44 +445,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.2",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.2.6",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.3",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.3",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.4",
-        "globals": "11.12.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.13.1",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.3",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.7.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       }
     },
     "eslint-config-hapi": {
@@ -497,11 +497,11 @@
       "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
       "dev": true,
       "requires": {
-        "hapi-capitalize-modules": "1.1.6",
-        "hapi-for-you": "1.0.0",
-        "hapi-no-var": "1.0.1",
-        "hapi-scope-start": "2.1.1",
-        "no-arrowception": "1.0.0"
+        "hapi-capitalize-modules": "1.x.x",
+        "hapi-for-you": "1.x.x",
+        "hapi-no-var": "1.x.x",
+        "hapi-scope-start": "2.x.x",
+        "no-arrowception": "1.x.x"
       }
     },
     "eslint-scope": {
@@ -510,8 +510,8 @@
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.3.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -526,8 +526,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -542,7 +542,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -551,7 +551,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -572,9 +572,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -600,7 +600,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -609,8 +609,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.4",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "find-rc": {
@@ -625,10 +625,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "graceful-fs": "4.2.2",
-        "rimraf": "2.6.3",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       },
       "dependencies": {
         "rimraf": {
@@ -637,7 +637,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.4"
+            "glob": "^7.1.3"
           }
         }
       }
@@ -658,12 +658,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -683,7 +683,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
       "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
       "requires": {
-        "iterall": "1.2.2"
+        "iterall": "^1.2.2"
       }
     },
     "graphql-tools": {
@@ -691,11 +691,11 @@
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
       "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
       "requires": {
-        "apollo-link": "1.2.13",
-        "apollo-utilities": "1.3.2",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.2.2",
-        "uuid": "3.3.3"
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
       }
     },
     "handlebars": {
@@ -704,10 +704,10 @@
       "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
-        "neo-async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.6.1"
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       }
     },
     "hapi-capitalize-modules": {
@@ -740,7 +740,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -760,7 +760,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -780,8 +780,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -795,20 +795,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.15",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       }
     },
     "is-fullwidth-code-point": {
@@ -864,10 +864,10 @@
       "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1",
-        "isemail": "2.2.1",
-        "items": "2.1.2",
-        "topo": "2.0.2"
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "topo": "2.x.x"
       }
     },
     "js-tokens": {
@@ -882,8 +882,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -898,7 +898,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -925,24 +925,24 @@
       "integrity": "sha512-IFnuYVRd6CtnFTFgUbjPCFrrCIked5BvGH/dX+/h+6pi3IrQrK21JsKy/J1CshEm6sMe980+oswtK8lZCusHSA==",
       "dev": true,
       "requires": {
-        "bossy": "3.0.4",
-        "code": "4.1.0",
-        "diff": "3.5.0",
-        "eslint": "4.19.1",
-        "eslint-config-hapi": "10.1.0",
-        "eslint-plugin-hapi": "4.1.0",
-        "espree": "3.5.4",
-        "find-rc": "3.0.1",
-        "handlebars": "4.4.3",
-        "hoek": "4.2.1",
-        "items": "2.1.2",
-        "json-stable-stringify": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "seedrandom": "2.4.4",
-        "source-map": "0.6.1",
-        "source-map-support": "0.4.18",
-        "supports-color": "4.4.0"
+        "bossy": "3.x.x",
+        "code": "4.1.x",
+        "diff": "3.5.x",
+        "eslint": "4.19.x",
+        "eslint-config-hapi": "10.x.x",
+        "eslint-plugin-hapi": "4.x.x",
+        "espree": "3.5.x",
+        "find-rc": "3.0.x",
+        "handlebars": "4.x.x",
+        "hoek": "4.x.x",
+        "items": "2.x.x",
+        "json-stable-stringify": "1.x.x",
+        "json-stringify-safe": "5.x.x",
+        "mkdirp": "0.5.x",
+        "seedrandom": "2.4.x",
+        "source-map": "0.6.x",
+        "source-map-support": "0.4.x",
+        "supports-color": "4.4.x"
       },
       "dependencies": {
         "has-flag": {
@@ -957,7 +957,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -968,8 +968,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -983,8 +983,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "mimic-fn": {
@@ -998,7 +998,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1057,7 +1057,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1066,7 +1066,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -1075,8 +1075,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -1093,12 +1093,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1160,13 +1160,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.4",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.1",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regexpp": {
@@ -1181,8 +1181,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -1191,7 +1191,7 @@
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -1206,8 +1206,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1216,7 +1216,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -1225,7 +1225,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -1240,7 +1240,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -1273,7 +1273,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1294,7 +1294,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "source-map": {
@@ -1309,7 +1309,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -1326,23 +1326,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1351,7 +1351,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1373,7 +1373,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "table": {
@@ -1382,12 +1382,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.2",
-        "lodash": "4.17.15",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "text-table": {
@@ -1408,7 +1408,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "topo": {
@@ -1417,7 +1417,7 @@
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "ts-invariant": {
@@ -1425,7 +1425,7 @@
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
       "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.3"
       }
     },
     "tslib": {
@@ -1439,19 +1439,19 @@
       "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.2",
-        "commander": "2.20.1",
-        "diff": "4.0.1",
-        "glob": "7.1.4",
-        "js-yaml": "3.13.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "resolve": "1.12.0",
-        "semver": "5.7.1",
-        "tslib": "1.10.0",
-        "tsutils": "2.29.0"
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^4.0.1",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "diff": {
@@ -1468,7 +1468,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.8.1"
       }
     },
     "type-check": {
@@ -1477,7 +1477,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -1500,7 +1500,7 @@
       "optional": true,
       "requires": {
         "commander": "2.20.0",
-        "source-map": "0.6.1"
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -1529,7 +1529,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -1549,7 +1549,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "yallist": {
@@ -1568,8 +1568,8 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
       "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
       "requires": {
-        "tslib": "1.10.0",
-        "zen-observable": "0.8.14"
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "Merge GraphQL Schema files and validate queries against the merged Schema",
   "repository": {
     "type": "git",

--- a/src/cli-launcher.ts
+++ b/src/cli-launcher.ts
@@ -7,11 +7,10 @@ in the src/ directory to validate all the files in the file glob CLI parameter.
 
 import * as program from 'commander';
 import * as fs from 'fs';
-import * as graphql from 'graphql';
 import * as path from 'path';
 import * as cli from './cli';
 import { consoleLogger } from './logger';
-import { printSchemaWithDirectives } from './utilities';
+import { printSchemaDefault, printSchemaWithDirectives } from './printers';
 // @ts-ignore
 const packageJson = require('../package.json');
 program
@@ -38,7 +37,7 @@ if (!program.schema) {
       if (program.includeDirectives) {
         data = printSchemaWithDirectives(schema);
       } else {
-        data = graphql.printSchema(schema);
+        data = printSchemaDefault(schema);
       }
       if (schema.getQueryType().toString() === 'Query' && (!schema.getMutationType()
         || schema.getMutationType().toString() === 'Mutation')

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -1,0 +1,395 @@
+import {
+    ArgumentNode,
+    astFromValue,
+    BooleanValueNode,
+    FloatValueNode,
+    GraphQLDirective,
+    GraphQLEnumType,
+    GraphQLInputObjectType,
+    GraphQLInterfaceType,
+    GraphQLNamedType,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    GraphQLUnionType,
+    IntValueNode,
+    isEnumType,
+    isInputObjectType,
+    isInterfaceType,
+    isIntrospectionType,
+    isObjectType,
+    isScalarType,
+    isSpecifiedDirective,
+    isSpecifiedScalarType,
+    isUnionType,
+    NullValueNode,
+    print,
+    printSchema,
+    StringValueNode,
+    ValueNode,
+} from 'graphql';
+import { printBlockString } from 'graphql/language/blockString';
+import flatMap from 'graphql/polyfills/flatMap';
+import objectValues from 'graphql/polyfills/objectValues';
+
+/**
+ * This method is a workaround for the issue of not being able to print the
+ * directives fields for the merged schema when using printSchema method
+ *
+ * This is mostly copied from GQL v14, but we differ from the reference
+ * implementation in how we handle printing directives.
+ *
+ * The existing implementation will not print directives declared on various
+ * parts of the AST instead relying on the actual application to handle those at evaluation time.
+ *
+ * However, our build system is used to re-present schemas. We need to preserve the directive information
+ * until the upstream systems can decided what to do with them.
+ *
+ * @param schema
+ */
+export function printSchemaWithDirectives(schema: GraphQLSchema): string {
+    return printFilteredSchema(
+        schema,
+        (n) => !isSpecifiedDirective(n),
+        isDefinedType,
+    );
+}
+
+export function printSchemaDefault(schema: GraphQLSchema): string {
+    return printSchema(schema);
+}
+
+function printFilteredSchema(
+    schema: GraphQLSchema,
+    directiveFilter: (type: GraphQLDirective) => boolean,
+    typeFilter: (type: GraphQLNamedType) => boolean,
+): string {
+    const directives = schema.getDirectives().filter(directiveFilter);
+    const typeMap = schema.getTypeMap();
+    const types = objectValues(typeMap)
+        .sort((type1, type2) => type1.name.localeCompare(type2.name))
+        .filter(typeFilter);
+
+    return (
+        [printSchemaDefinition(schema)]
+            .concat(
+                directives.map((directive) => printDirective(directive)),
+                types.map((type) => printType(type)),
+            )
+            .filter(Boolean)
+            .join('\n\n') + '\n'
+    );
+
+}
+
+function printType(type: GraphQLNamedType): string {
+    if (isScalarType(type)) {
+        return printScalar(type);
+    } else if (isObjectType(type)) {
+        return printObject(type);
+    } else if (isInterfaceType(type)) {
+        return printInterface(type);
+    } else if (isUnionType(type)) {
+        return printUnion(type);
+    } else if (isEnumType(type)) {
+        return printEnum(type);
+    } else if (isInputObjectType(type)) {
+        return printInputObject(type);
+    }
+
+    // Not reachable. All possible types have been considered.
+    throw Error('Unexpected type: ' +  type);
+}
+
+function printScalar(type: GraphQLScalarType): string {
+    return printDescription(type) + `scalar ${type.name}`;
+}
+
+function printObject(type: GraphQLObjectType): string {
+    const interfaces = type.getInterfaces();
+    const implementedInterfaces = interfaces.length
+        ? ' implements ' + interfaces.map((i) => i.name).join(' & ')
+        : '';
+    return (
+        printDescription(type) +
+        `type ${type.name}${implementedInterfaces}` +
+        printFields(type)
+    );
+}
+
+function printInterface(type: GraphQLInterfaceType): string {
+    return (
+        printDescription(type) +
+        `interface ${type.name}` +
+        printFields(type)
+    );
+}
+
+function printUnion(type: GraphQLUnionType): string {
+    const types = type.getTypes();
+    const possibleTypes = types.length ? ' = ' + types.join(' | ') : '';
+    return printDescription(type) + 'union ' + type.name + possibleTypes;
+}
+
+function printEnum(type: GraphQLEnumType): string {
+    const values = type
+        .getValues()
+        .map(
+            (value, i) =>
+                printDescription(value, '  ', !i) +
+                '  ' +
+                value.name +
+                printDirectiveField(value),
+        );
+
+    return (
+        printDescription(type) + `enum ${type.name}` + printBlock(type, values)
+    );
+}
+
+function printInputObject(type: GraphQLInputObjectType): string {
+    const fields = printInputFields(type);
+    return (
+        printDescription(type) +
+        `input ${type.name}` +
+        printBlock(type, fields)
+    );
+}
+
+function printInputFields(type) {
+    return objectValues(type.getFields()).map(
+        (f, i) =>
+            printDescription(f, '  ', !i) +
+            '  ' +
+            printInputValue(f),
+    );
+}
+
+function printFields(type) {
+    const fields = objectValues(type.getFields()).map(
+        (f, i) =>
+            printDescription(f, '  ', !i) +
+            '  ' +
+            f.name +
+            printArgs(f.args, '  ') +
+            ': ' +
+            String(f.type) +
+            printDirectiveField(f),
+    );
+    return printBlock(type, fields);
+}
+
+function printDirectiveField(field) {
+    const node = field.astNode;
+    return printDirectiveNode(node);
+}
+
+function printDirectiveNode(node) {
+    if (!node || !node.directives || node.directives.length === 0) {
+        return '';
+    }
+
+    const directives = node.directives.map(
+        (directive) => {
+            let directiveString = '';
+            directiveString += ' @';
+            directiveString += directive.name.value;
+
+            if (directive.arguments.length > 0) {
+                directiveString += '(';
+                directive.arguments.forEach((arg, i) => {
+                    directiveString += printArgument(arg);
+                    if (i !== directive.arguments.length - 1) {
+                        directiveString += ', ';
+                    }
+                });
+                directiveString += ')';
+            }
+            return directiveString;
+        });
+
+    return directives.join('');
+}
+
+function printArgument(node: ArgumentNode) {
+    return node.name.value
+        + ': '
+        + printArgumentValueNode(node.value);
+}
+
+function printBlock(type, items) {
+    const directiveStatement = printDirectiveNode(type.astNode);
+    if (items.length !== 0) {
+        return directiveStatement + ' {\n' + items.join('\n') + '\n}';
+    } else {
+        return '';
+    }
+}
+
+function isDefinedType(type: GraphQLNamedType): boolean {
+    return !isSpecifiedScalarType(type) && !isIntrospectionType(type);
+}
+
+function printSchemaDefinition(schema: GraphQLSchema): string {
+    if (isSchemaOfCommonNames(schema)) {
+        return;
+    }
+
+    const operationTypes = [];
+
+    const queryType = schema.getQueryType();
+    if (queryType) {
+        operationTypes.push(`  query: ${queryType.name}`);
+    }
+
+    const mutationType = schema.getMutationType();
+    if (mutationType) {
+        operationTypes.push(`  mutation: ${mutationType.name}`);
+    }
+
+    const subscriptionType = schema.getSubscriptionType();
+    if (subscriptionType) {
+        operationTypes.push(`  subscription: ${subscriptionType.name}`);
+    }
+
+    return `schema {\n${operationTypes.join('\n')}\n}`;
+}
+
+function isSchemaOfCommonNames(schema: GraphQLSchema): boolean {
+    const queryType = schema.getQueryType();
+    if (queryType && queryType.name !== 'Query') {
+        return false;
+    }
+
+    const mutationType = schema.getMutationType();
+    if (mutationType && mutationType.name !== 'Mutation') {
+        return false;
+    }
+
+    const subscriptionType = schema.getSubscriptionType();
+    return !(subscriptionType && subscriptionType.name !== 'Subscription');
+}
+
+function printDirective(directive) {
+    return (
+        printDescription(directive) +
+        'directive @' +
+        directive.name +
+        printArgs(directive.args) +
+        (directive.isRepeatable ? ' repeatable' : '') +
+        ' on ' +
+        directive.locations.join(' | ')
+    );
+}
+
+function printDescription(
+    def,
+    indentation = '',
+    firstInBlock = true,
+): string {
+    if (!def.description) {
+        return '';
+    }
+    const lines = descriptionLines(def.description, 120 - indentation.length);
+    const text = lines.join('\n');
+    const preferMultipleLines = text.length > 70;
+    const blockString = printBlockString(text, '', preferMultipleLines);
+    const prefix =
+        indentation && !firstInBlock ? '\n' + indentation : indentation;
+
+    return prefix + blockString.replace(/\n/g, '\n' + indentation) + '\n';
+}
+
+function printArgs(args, indentation = '') {
+    if (args.length === 0) {
+        return '';
+    }
+
+    // If every arg does not have a description, print them on one line.
+    if (args.every((arg) => !arg.description)) {
+        return '(' + args.map(printInputValue).join(', ') + ')';
+    }
+
+    return (
+        '(\n' +
+        args
+            .map(
+                (arg, i) =>
+                    printDescription(arg, '  ' + indentation, !i) +
+                    '  ' +
+                    indentation +
+                    printInputValue(arg),
+            )
+            .join('\n') +
+        '\n' +
+        indentation +
+        ')'
+    );
+}
+
+function printInputValue(arg) {
+    const defaultAST = astFromValue(arg.defaultValue, arg.type);
+    // printDirectiveNode
+    let argDecl = arg.name + ': ' + String(arg.type) + printDirectiveField(arg);
+    if (defaultAST) {
+        argDecl += ` = ${print(defaultAST)}`;
+    }
+    return argDecl;
+}
+
+function printArgumentValueNode(type: ValueNode) {
+    switch (type.kind) {
+        case 'BooleanValue':
+            return printLiteralArgumentValueNode(type as BooleanValueNode);
+
+        case 'FloatValue':
+            return printLiteralArgumentValueNode(type as FloatValueNode);
+
+        case 'IntValue':
+            return printLiteralArgumentValueNode(type as IntValueNode);
+
+        case 'NullValue':
+            return printNullValueNode(type as NullValueNode);
+
+        case 'StringValue':
+            return printStringValueNode(type as StringValueNode);
+    }
+
+    throw Error('Cannot print complex directive of type: ' + String(type.kind));
+}
+
+function printLiteralArgumentValueNode(node: IntValueNode | FloatValueNode | BooleanValueNode) {
+    return node.value;
+}
+
+function printStringValueNode(node: StringValueNode) {
+    return '"' + node.value + '"';
+}
+
+function printNullValueNode(node: NullValueNode) {
+    return null;
+}
+
+function descriptionLines(description: string, maxLen: number): string[] {
+    const rawLines = description.split('\n');
+    return flatMap(rawLines, (line) => {
+        if (line.length < maxLen + 5) {
+            return line;
+        }
+        // For > 120 character long lines, cut at space boundaries into sublines
+        // of ~80 chars.
+        return breakLine(line, maxLen);
+    });
+}
+
+function breakLine(line: string, maxLen: number): string[] {
+    const parts = line.split(new RegExp(`((?: |^).{15,${maxLen - 40}}(?= |$))`));
+    if (parts.length < 4) {
+        return [line];
+    }
+    const sublines = [parts[0] + parts[1] + parts[2]];
+    for (let i = 3; i < parts.length; i += 2) {
+        sublines.push(parts[i].slice(1) + parts[i + 1]);
+    }
+    return sublines;
+}

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -11,7 +11,6 @@ import * as graphql from 'graphql';
 import * as mkdirp from 'mkdirp';
 import * as rimraf from 'rimraf';
 import * as cli from '../cli';
-import * as srcmap from '../validate-schema';
 
 describe('GraphQL Validator CLI', () => {
   describe('#mergeGQLSchemas', () => {

--- a/src/test/printers.test.ts
+++ b/src/test/printers.test.ts
@@ -1,0 +1,93 @@
+import { expect } from 'code';
+import * as Lab from 'lab';
+export const lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const before = lab.before;
+
+import * as fs from 'fs';
+import * as cli from '../cli';
+import * as printers from '../printers';
+
+describe('GraphQL Schema Printers', () => {
+    describe('#printSchemaWithDirectives', () => {
+        describe(`When loading and printing a schema with directives.`, () => {
+            const glob = './fixtures/directiveSchemas/**/*.graphql';
+            let printedSchema;
+            before((done) => {
+                cli.mergeGQLSchemas(glob).then((s) => {
+                    printedSchema = printers.printSchemaWithDirectives(s);
+                    done();
+                });
+            });
+
+            it('Has symmetric equality preserving directives', (done) => {
+                expect(printedSchema).to.exist();
+                const expectedSchema: string = fs.readFileSync(
+                    './fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql', 'utf8');
+                expect(printedSchema).to.equal(expectedSchema);
+                done();
+            });
+        });
+
+        describe(`When loading and printing the canonical schema example.`, () => {
+            const glob = './fixtures/helloWorld/**/*.graphql';
+            let printedSchema: string;
+            before((done) => {
+                cli.mergeGQLSchemas(glob).then((s) => {
+                    printedSchema = printers.printSchemaWithDirectives(s);
+                    done();
+                });
+            });
+
+            it('Has symmetric equality preserving directives', (done) => {
+                expect(printedSchema).to.exist();
+                const expectedSchema: string = fs.readFileSync(
+                    './fixtures/expectedOutput/helloWorld/expectedOutput.graphql', 'utf8');
+                expect(printedSchema).to.equal(expectedSchema);
+                done();
+            });
+        });
+    });
+
+    describe('#printSchemaDefault', () => {
+        describe(`When loading and printing a schema with directives.`, () => {
+            const glob = './fixtures/directiveSchemas/**/*.graphql';
+            let printedSchema: string;
+            before((done) => {
+                cli.mergeGQLSchemas(glob).then((s) => {
+                    printedSchema = printers.printSchemaDefault(s);
+                    done();
+                });
+            });
+
+            it('Has symmetric equality without custom directives', (done) => {
+                expect(printedSchema).to.exist();
+                const expectedSchema: string = fs.readFileSync(
+                    './fixtures/expectedOutput/directiveSchemas/printedDefault.graphql', 'utf8');
+                expect(printedSchema).to.equal(expectedSchema);
+                done();
+            });
+        });
+
+        describe(`When loading and printing the canonical schema example with directives.`, () => {
+            const glob = './fixtures/helloWorld/**/*.graphql';
+            let printedSchema: string;
+            before((done) => {
+                cli.mergeGQLSchemas(glob).then((s) => {
+                    printedSchema = printers.printSchemaWithDirectives(s);
+                    done();
+                });
+            });
+
+            it('Has symmetric equality preserving directives', (done) => {
+                expect(printedSchema).to.exist();
+                const expectedSchema: string = fs.readFileSync(
+                    './fixtures/expectedOutput/helloWorld/expectedOutput.graphql', 'utf8');
+                expect(printedSchema).to.equal(expectedSchema);
+                done();
+            });
+        });
+    });
+});

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as globUtil from 'glob';
-import { GraphQLSchema, isSpecifiedDirective, isSpecifiedScalarType, print } from 'graphql';
 
 export function readGlob(pattern: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -19,29 +18,4 @@ export function readFile(file: string): Promise<string> {
       err ? reject(err) : resolve(data),
     );
   });
-}
-
-/**
- * This method is a workaround for the issue of not being able to print the
- * directives fields for the merged schema when using printSchema method
- * @param schema
- */
-export function printSchemaWithDirectives(schema: GraphQLSchema): string {
-  const str = Object
-    .keys(schema.getTypeMap())
-    .filter((k) => !k.match(/^__/))
-    .reduce((accum, name) => {
-      const type = schema.getType(name);
-      return !isSpecifiedScalarType(type)
-        ? accum += `${print(type.astNode)}\n`
-        : accum;
-    }, '');
-
-  return schema
-    .getDirectives()
-    .reduce((accum, d) => {
-      return !isSpecifiedDirective(d)
-        ? accum += `${print(d.astNode)}\n`
-        : accum;
-    }, str + `${print(schema.astNode)}\n`);
 }


### PR DESCRIPTION
The GraphQL schema printer drops directives (with the exception of
deprecated). This commit offers an alternative printers that will leave
directives intact. Because our tool is merging and validating multiple
schemas (stitching), to represent to some evaluation layer, we want
those directives to be preserved on output.

We utilize GQL's AST api where possible because all directives are
intact in the AST, even if not directly represented in the Fields. The
AST approach should be extensible for more directive types.

This feature is most likely not complete. It handles a subset of all
places directives can apply on the tree, but it is a start and handles
all known tracking issues (and tests to demonstrate).

Again, bear in mind that 'deprecated' is a special case. In the tests,
you will see that the withoutDirective fixtures still include
deprecated, which is modeled as a first class directive by the GQL core
code base.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
