### PR TITLE
Adding err to catch all exception handler

### DIFF
--- a/src/cli-launcher.ts
+++ b/src/cli-launcher.ts
@@ -83,7 +83,7 @@ if (!program.schema) {
     },
     )
     .catch((err) => {
-      consoleLogger.error('Could not merge Schema files!\n');
+      consoleLogger.error('Could not merge Schema files!\n', err);
       process.exit(1);
     });
 }


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*

Adding the `err` to the `consoleLogger()` for getting information on what could've caused a Schema merge failure. Was recently useful for me when I had multiple versions of `graphql` installed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
