### PR TITLE
Add quiet option to CLI, to suppress non error logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Merge GraphQL Schema files and validate queries against the merged Schema",
   "repository": {
     "type": "git",

--- a/src/cli-launcher.ts
+++ b/src/cli-launcher.ts
@@ -26,6 +26,8 @@ program
     'Use a glob that that contains your graphql operation files to test against the merged schema file.', '')
   .option('-d, --includeDirectives',
     'By default will NOT merge the directives, unless you added this flag.', false)
+  .option('-q, --quiet',
+   'Run in quite mode, suppressing all logs except errors.', false)
   .parse(process.argv);
 
 if (!program.schema) {
@@ -49,7 +51,11 @@ if (!program.schema) {
               ? '\n  subscription: Subscription' : ''}  \n}\n\n`;
         data = typeDefs + data;
       }
-      process.stdout.write(data);
+
+      if (!program.quiet) {
+        process.stdout.write(data);
+      }
+
       if (program.output) {
         ensureDirectoryExistence(program.output);
         fs.writeFile(program.output, data, (err) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   makeExecutableSchema,
 } from 'graphql-tools';
 import * as validator from './index';
+import { consoleLogger } from './logger';
 import { ValidationRule } from './types';
 import * as utils from './utilities';
 import { validateSchemaWithSourceMap } from './validate-schema';
@@ -24,11 +25,11 @@ import { validateSchemaWithSourceMap } from './validate-schema';
  */
 export function mergeGQLSchemas(schemaPattern: string): Promise<GraphQLSchema> {
   return new Promise((resolve, reject) => {
-    console.log(`\nLoading schema from ${schemaPattern}`);
+    consoleLogger.log(`\nLoading schema from ${schemaPattern}`);
     utils.readGlob(schemaPattern).then((files) => {
       if (!files.length) {
         const noFilesMatching = `No matching files were found with Glob: ${schemaPattern}.`;
-        console.error(noFilesMatching);
+        consoleLogger.error(noFilesMatching);
         reject(new Error(noFilesMatching));
       }
       Promise.all(
@@ -37,7 +38,7 @@ export function mergeGQLSchemas(schemaPattern: string): Promise<GraphQLSchema> {
             .readFile(file)
             .then((subSchema: string) => subSchema)
             .catch((error) => {
-              console.error(
+              consoleLogger.error(
                 `An error occurred while trying to read your graphql schemas in ${schemaPattern}. \n`,
                 error,
               );
@@ -71,25 +72,25 @@ export function validateOperations(
   rules?: ReadonlyArray<ValidationRule>,
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    console.log(
+    consoleLogger.log(
       `\nValidating queries for ${queriesPattern} using loaded schema`,
     );
 
     function outputErrors(errs) {
-      console.log('\nErrors found:');
+      consoleLogger.log('\nErrors found:');
       errs.forEach((err) => {
-        console.log(`\nFile: ${err.file}`);
+        consoleLogger.log(`\nFile: ${err.file}`);
         err.errors.forEach((errStr) => {
-          console.log(`\t${errStr}`);
+          consoleLogger.log(`\t${errStr}`);
         });
       });
-      console.log('\n');
+      consoleLogger.log('\n');
     }
 
     validator
       .validateQueryFiles(queriesPattern, validSchema, rules)
       .then(() => {
-        console.log('All queries are valid\n');
+        consoleLogger.log('All queries are valid\n');
         resolve();
       })
       .catch((errs) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+import * as program from 'commander';
+
 export interface ILogger {
   error(...args);
   warn(...args);
@@ -12,11 +14,15 @@ export class ConsoleLogger implements ILogger {
   }
 
   public log(message: string, ...args) {
-    console.log(message, args.length ? args : '');
+    if (!program.quiet) {
+      console.log(message, args.length ? args : '');
+    }
   }
 
   public warn(warnMessage: string, ...args) {
-    console.warn(chalk.yellow(warnMessage), args.length ? args : '');
+    if (!program.quiet) {
+      console.warn(chalk.yellow(warnMessage), args.length ? args : '');
+    }
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#28

*Description of changes:*
Add the `-q`/`--quiet` option to the CLI, to suppress any output other than error logs. Also changed `cli` module to use the library's logger instead of `console`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
