### PR TITLE
Enable copying directives of union

### DIFF
--- a/fixtures/directiveSchemas/directives.graphql
+++ b/fixtures/directiveSchemas/directives.graphql
@@ -7,3 +7,6 @@ directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
 """This directive demonstrates null types."""
 directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT
 
+"""The directives decorates unions."""
+directive @nestedFooUnion on UNION
+union NestedFooUnion @nestedFooUnion = NestedFoo

--- a/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
@@ -9,6 +9,9 @@ directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
 """This directive demonstrates null types."""
 directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT
 
+"""The directives decorates unions."""
+directive @nestedFooUnion on UNION
+
 enum Bar {
   MORE
   VALUES
@@ -31,3 +34,5 @@ type NestedFoo {
   anotherAttribute: String!
   oldAttribute: String! @deprecated(reason: "reason")
 }
+
+union NestedFooUnion = NestedFoo

--- a/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
@@ -9,6 +9,9 @@ directive @noArg on ENUM_VALUE | FIELD_DEFINITION | OBJECT
 """This directive demonstrates null types."""
 directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT
 
+"""The directives decorates unions."""
+directive @nestedFooUnion on UNION
+
 enum Bar {
   MORE @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14, listArg: ["string"], enumArg: VALUES)
   VALUES
@@ -31,3 +34,5 @@ type NestedFoo {
   anotherAttribute: String! @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14, listArg: ["string"], enumArg: VALUES) @noArg
   oldAttribute: String! @deprecated(reason: "reason")
 }
+
+union NestedFooUnion @nestedFooUnion = NestedFoo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Merge GraphQL Schema files and validate queries against the merged Schema",
   "repository": {
     "type": "git",

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -130,7 +130,7 @@ function printInterface(type: GraphQLInterfaceType): string {
 function printUnion(type: GraphQLUnionType): string {
     const types = type.getTypes();
     const possibleTypes = types.length ? ' = ' + types.join(' | ') : '';
-    return printDescription(type) + 'union ' + type.name + possibleTypes;
+    return printDescription(type) + 'union ' + type.name + printDirectiveNode(type.astNode) + possibleTypes;
 }
 
 function printEnum(type: GraphQLEnumType): string {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently this tool skips copying directives on union. e.g. 
```
directive @fruitA on UNION
union Fruit @fruitA = Apple | Banana
```
and generates the following result
```
union Fruit = Apple | Banana
```
which does not include @fruitA directive. 

The merge result will be off when users have directives on union in their schema.
This fix copies directives "fruitA"  of the union, and make sure the merge result is aligned with user's schemas.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
