### PR TITLE
Input object in directive

### DIFF
--- a/fixtures/expectedOutput/inputObjectInDirective/printedInputObject.graphql
+++ b/fixtures/expectedOutput/inputObjectInDirective/printedInputObject.graphql
@@ -1,0 +1,28 @@
+directive @color(colors: ColorInput) on OBJECT
+
+directive @horror on OBJECT
+
+type Book @horror {
+  id: ID
+  name: String
+}
+
+enum Color {
+  Red
+  Blue
+}
+
+input ColorInput {
+  color: Color
+  OR: [ColorInput]
+  AND: [ColorInput]
+}
+
+type Page @color(colors: {OR: [{color: Blue}, {color: Red}]}) {
+  id: ID
+  content: String
+}
+
+type Query {
+  book: Book
+}

--- a/fixtures/inputObjectInDirective/directiveWithObject.graphql
+++ b/fixtures/inputObjectInDirective/directiveWithObject.graphql
@@ -1,0 +1,17 @@
+directive @color(colors: ColorInput) on OBJECT
+
+type Page @color(colors: {OR : [{color : Blue}, {color : Red}]}) {
+    id: ID
+    content: String
+}
+
+input ColorInput {
+    color: Color
+    OR: [ColorInput]
+    AND: [ColorInput]
+}
+
+enum Color {
+    Red
+    Blue
+}

--- a/fixtures/inputObjectInDirective/directiveWithoutObject.graphql
+++ b/fixtures/inputObjectInDirective/directiveWithoutObject.graphql
@@ -1,0 +1,10 @@
+type Query {
+    book: Book
+}
+
+directive @horror on OBJECT
+
+type Book @horror {
+    id: ID
+    name: String
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-utilities",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Merge GraphQL Schema files and validate queries against the merged Schema",
   "repository": {
     "type": "git",

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -25,6 +25,7 @@ import {
     isUnionType,
     ListValueNode,
     NullValueNode,
+    ObjectValueNode,
     print,
     printSchema,
     StringValueNode,
@@ -360,6 +361,9 @@ function printArgumentValueNode(type: ValueNode) {
 
         case 'EnumValue':
             return printEnumValueNode(type as EnumValueNode);
+
+        case 'ObjectValue':
+            return printObjectValueNode(type as ObjectValueNode);
     }
 
     throw Error('Cannot print complex directive of type: ' + String(type.kind));
@@ -383,6 +387,14 @@ function printListValueNode(node: ListValueNode) {
 
 function printEnumValueNode(node: EnumValueNode) {
     return node.value;
+}
+
+function printObjectValueNode(node) {
+    return '{' + node.fields.map(printObjectField).join(', ') + '}';
+}
+
+function printObjectField(field) {
+    return field.name.value + ': ' + printArgumentValueNode(field.value);
 }
 
 function descriptionLines(description: string, maxLen: number): string[] {

--- a/src/test/printers.test.ts
+++ b/src/test/printers.test.ts
@@ -49,6 +49,25 @@ describe('GraphQL Schema Printers', () => {
                 done();
             });
         });
+
+        describe(`When loading and printing the custom input object in directive arguments.`, () => {
+            const glob = './fixtures/inputObjectInDirective/**/*.graphql';
+            let printedSchema: string;
+            before((done) => {
+                cli.mergeGQLSchemas(glob).then((s) => {
+                    printedSchema = printers.printSchemaWithDirectives(s);
+                    done();
+                });
+            });
+
+            it('Has symmetric equality preserving directives', (done) => {
+                expect(printedSchema).to.exist();
+                const expectedSchema: string = fs.readFileSync(
+                    './fixtures/expectedOutput/inputObjectInDirective/printedInputObject.graphql', 'utf8');
+                expect(printedSchema).to.equal(expectedSchema);
+                done();
+            });
+        });
     });
 
     describe('#printSchemaDefault', () => {


### PR DESCRIPTION
### Issues
When a schema file having custom input object as a directive argument is merged with another schema file , the merging operation fails with error as `Cannot print complex directive of type:ObjectValue`.

### Root Cause
Handling of complex directive (i.e. its argument containing a custom input object ) is not supported as of now.

### Description of changes:

- Added the case for handling ObjectValue in printers.ts .
- Changed the project version.

### Testing:

- All tests which are part of packages getting passed.
- Verified the issue using graphql schema files attached in fixtures directory and then running merge command on them .
- Added a test case in printers.test.ts by taking graphql schema files attached in fixtures directory

```

Loading schema from ./fixtures/directiveSchemas/**/*.graphql 
.
Loading schema from ./fixtures/helloWorld/**/*.graphql 
.
Loading schema from ./fixtures/inputObjectInDirective/**/*.graphql 
.
Loading schema from ./fixtures/directiveSchemas/**/*.graphql 
.
Loading schema from ./fixtures/helloWorld/**/*.graphql 
.

36 tests complete
Test duration: 132 ms
Assertions count: 50 (verbosity: 1.39)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
