### PR TITLE
Support interfaces implmenting interfaces when --includeDirectives is…

### DIFF
--- a/fixtures/directiveSchemas/baseTypes.graphql
+++ b/fixtures/directiveSchemas/baseTypes.graphql
@@ -1,4 +1,13 @@
-type Foo @noArg {
+interface BarInterface {
+  bar: String!
+}
+
+interface FooInterface implements BarInterface {
+  bar: String!
+  nestedFoo: NestedFoo! @nullArg(stringArg: null)
+}
+
+type Foo implements FooInterface @noArg {
   bar: String!
   qux: Int!
   nestedFoo: NestedFoo! @nullArg(stringArg: null)

--- a/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
@@ -9,7 +9,16 @@ directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_F
 """The directives decorates unions."""
 directive @nestedFooUnion on UNION
 
-type Foo {
+interface BarInterface {
+  bar: String!
+}
+
+interface FooInterface implements BarInterface {
+  bar: String!
+  nestedFoo: NestedFoo!
+}
+
+type Foo implements FooInterface {
   bar: String!
   qux: Int!
   nestedFoo: NestedFoo!

--- a/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
@@ -15,9 +15,18 @@ enum Bar {
   EVERYONE
 }
 
-type Foo @noArg {
+interface BarInterface {
+  bar: String!
+}
+
+type Foo implements FooInterface @noArg {
   bar: String!
   qux: Int!
+  nestedFoo: NestedFoo! @nullArg(stringArg: null)
+}
+
+interface FooInterface implements BarInterface {
+  bar: String!
   nestedFoo: NestedFoo! @nullArg(stringArg: null)
 }
 

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -107,22 +107,28 @@ function printScalar(type: GraphQLScalarType): string {
     return printDescription(type) + `scalar ${type.name}`;
 }
 
-function printObject(type: GraphQLObjectType): string {
+
+function getImplementedInterfaces(type: GraphQLObjectType | GraphQLInterfaceType): string {
     const interfaces = type.getInterfaces();
     const implementedInterfaces = interfaces.length
         ? ' implements ' + interfaces.map((i) => i.name).join(' & ')
         : '';
-    return (
-        printDescription(type) +
-        `type ${type.name}${implementedInterfaces}` +
-        printFields(type)
-    );
+    return implementedInterfaces;
 }
 
 function printInterface(type: GraphQLInterfaceType): string {
+    const implementedInterfaces = getImplementedInterfaces(type);
     return (
         printDescription(type) +
-        `interface ${type.name}` +
+        `interface ${type.name}${implementedInterfaces}` +
+        printFields(type)
+    );
+}
+function printObject(type: GraphQLObjectType): string {
+    const implementedInterfaces = getImplementedInterfaces(type);
+    return (
+        printDescription(type) +
+        `type ${type.name}${implementedInterfaces}` +
         printFields(type)
     );
 }


### PR DESCRIPTION
PR to fix "Interfaces implementing other interfaces loose implements clause when --includeDirectives option set" #50.

*Issue:* #50 

*Description of changes:*
The `printFilteredSchema` method in `printers.ts` (used when --includeDirectives is set) previously did not include logic for checking if a `GraphQLInterfaceType` implemented any parent interfaces. This change moves the existing logic for printing a `GraphQLObjectType` which includes printing implemented interfaces into a common function  `getImplementedInterfaces` that is used by both `GraphQLInterfaceType` and `GraphQLObjectType` for handling parent interfaces.

Test cases are updated to include a use-case where an interface implements another interface.
