### PR TITLE
Retaining escape characters as part of directive argument value.

### DIFF
--- a/fixtures/directiveSchemas/baseTypes.graphql
+++ b/fixtures/directiveSchemas/baseTypes.graphql
@@ -27,4 +27,5 @@ enum Bar {
 input Input {
   field: String @nullArg(stringArg: "string")
   oldAttribute: String! @deprecated(reason: "reason")
+  fieldWithEscapeString: String @escapedStringArg(escapedString: "\b,\f,\n,\r,\t,...,\\,{,}")
 }

--- a/fixtures/directiveSchemas/directives.graphql
+++ b/fixtures/directiveSchemas/directives.graphql
@@ -10,3 +10,6 @@ directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_F
 """The directives decorates unions."""
 directive @nestedFooUnion on UNION
 union NestedFooUnion @nestedFooUnion = NestedFoo
+
+"""The directive accepts escaped string."""
+directive @escapedStringArg(escapedString: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION

--- a/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedDefault.graphql
@@ -9,6 +9,9 @@ directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_F
 """The directives decorates unions."""
 directive @nestedFooUnion on UNION
 
+"""The directive accepts escaped string."""
+directive @escapedStringArg(escapedString: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 interface BarInterface {
   bar: String!
 }
@@ -40,6 +43,7 @@ enum Bar {
 input Input {
   field: String
   oldAttribute: String! @deprecated(reason: "reason")
+  fieldWithEscapeString: String
 }
 
 union NestedFooUnion = NestedFoo

--- a/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
+++ b/fixtures/expectedOutput/directiveSchemas/printedWithDirectives.graphql
@@ -9,6 +9,9 @@ directive @nullArg(stringArg: String) on ENUM_VALUE | FIELD_DEFINITION | INPUT_F
 """The directives decorates unions."""
 directive @nestedFooUnion on UNION
 
+"""The directive accepts escaped string."""
+directive @escapedStringArg(escapedString: String) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
 enum Bar {
   MORE @multiArgAndType(stringArg: "string", booleanArg: true, intArg: 314, floatArg: 3.14, listArg: ["string"], enumArg: VALUES)
   VALUES
@@ -33,6 +36,7 @@ interface FooInterface implements BarInterface {
 input Input {
   field: String @nullArg(stringArg: "string")
   oldAttribute: String! @deprecated(reason: "reason")
+  fieldWithEscapeString: String @escapedStringArg(escapedString: "\b,\f,\n,\r,\t,...,\\,{,}")
 }
 
 type NestedFoo {

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -380,7 +380,7 @@ function printLiteralArgumentValueNode(node: IntValueNode | FloatValueNode | Boo
 }
 
 function printStringValueNode(node: StringValueNode) {
-    return '"' + node.value + '"';
+    return JSON.stringify(node.value);
 }
 
 function printNullValueNode(node: NullValueNode) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While printing schemas tooling was not handling escape characters properly if they are part of directive argument values. 
e.g. charater like `\b`  ends up not being retained in exported schema. 

Fix allows retaining of escape values in directive arguments. 

Works for usecase like [@pattern](https://github.com/graphql-java/graphql-java-extended-validation) directive 



---------------------------------------------------------------------------------------------------------------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
